### PR TITLE
Fix sub-chart redis config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -129,3 +129,5 @@ dmypy.json
 
 # editors
 .idea/
+
+.helm-charts/

--- a/helm/templates/config/secret.yaml
+++ b/helm/templates/config/secret.yaml
@@ -24,8 +24,8 @@ stringData:
   EMAIL_HOST_PASSWORD: {{ required "secrets.EMAIL_HOST_PASSWORD" .Values.secrets.EMAIL_HOST_PASSWORD | quote }}
   # Redis
   {{- if .Values.redis.enabled }}
-  CELERY_BROKER_URL: "redis://{{ printf "%s-master" (include "common.names.fullname" .Subcharts.redis) }}/6379/0"
-  CACHE_REDIS_URL: "redis://{{ printf "%s-master" (include "common.names.fullname" .Subcharts.redis) }}/6379/1"
+  CELERY_BROKER_URL: "redis://{{ printf "%s-master" (include "common.names.fullname" .Subcharts.redis) }}:6379/0"
+  CACHE_REDIS_URL: "redis://{{ printf "%s-master" (include "common.names.fullname" .Subcharts.redis) }}:6379/1"
   {{- else }}
   CELERY_BROKER_URL: {{ required "env.CELERY_BROKER_URL" .Values.env.CELERY_BROKER_URL | quote }}
   CACHE_REDIS_URL: {{ required "env.CACHE_REDIS_URL" .Values.env.CACHE_REDIS_URL | quote }}

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -12,6 +12,8 @@ redis:
   enabled: true
   architecture: standalone
   fullnameOverride: alert-hub-redis
+  auth:
+    enabled: false
   master:
     persistence:
       enabled: true


### PR DESCRIPTION
Addresses
- Helm redis issue

## Changes

* Disable auth (Used for local cluster only)
* Fix sub-chart service used in api/worker configmap

## This PR doesn't introduce any:

- [x] temporary files, auto-generated files or secret keys
- [x] n+1 queries
- [x] flake8 issues
- [x] `print`
- [x] typos
- [x] unwanted comments

## This PR contains valid:

- [ ] tests
- [ ] permission checks (tests here too)
- [ ] translations