### PR TITLE
Adjust resources for staging cluster

### DIFF
--- a/helm/values-staging.yaml
+++ b/helm/values-staging.yaml
@@ -14,32 +14,62 @@ redis:
   master:
     resourcesPreset: micro  # https://github.com/bitnami/charts/blob/main/bitnami/common/templates/_resources.tpl#L16
 
+# FIXME: Use proper requests.cpu
 worker:
-  enabled: true
-  resources:
-    requests:
-      cpu: "2"
-      memory: 2Gi
-    limits:
-      cpu: "4"
-      memory: 4Gi
   beat:
     resources:
       requests:
         cpu: "0.1"
-        memory: 0.1Gi
+        memory: 0.5Gi
       limits:
-        cpu: "4"
+        cpu: "1"
         memory: 1Gi
+  flower:
+    resources:
+      requests:
+        cpu: "0.1"
+        memory: 0.5Gi
+      limits:
+        cpu: "1"
+        memory: 1Gi
+  queues:
+    # NOTE: Make sure keys are lowercase
+    default:
+      replicaCount: 2
+      resources:
+        requests:
+          cpu: "0.1"
+          memory: 1Gi
+        limits:
+          cpu: "1"
+          memory: 2Gi
+    feeds:
+      replicaCount: 1
+      resources:
+        requests:
+          cpu: "0.2"
+          memory: 1Gi
+        limits:
+          cpu: "1"
+          memory: 2Gi
 
+# FIXME: Use proper requests.cpu
 api:
   resources:
     requests:
-      cpu: "2"
+      cpu: "0.2"
       memory: 1Gi
     limits:
       cpu: "4"
       memory: 2Gi
+
+argoHooks:
+  # NOTE: Make sure keys are lowercase
+  db-migrate:
+    requestsCpu: 0.1
+    requestsMemory: 1G
+    limitsCpu: 4
+    limitsMemory: 2G
 
 env:
   DJANGO_DEBUG: false


### PR DESCRIPTION
Fix resource allocations issue
```
Warning  FailedScheduling   33m (x169 over 11h)        default-scheduler   0/5 nodes are available: 5 Insufficient cpu. preemption: 0/5 nodes are available: 5 No preemption victims found for incoming pod..
```